### PR TITLE
Add basic coding challenge with failing test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,13 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+# Gradle build
+/build/
+.gradle/
+
+# IntelliJ files
+*.iml
+.idea/
+
+# macOS files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# JavaTest Coding Challenge
+
+This simple project contains a failing unit test that you can use to evaluate prospective team members. Candidates should fix the bug in `Calculator.java` so that the unit test passes.
+
+## Instructions
+
+1. Ensure you have Java (17+) and Gradle installed.
+2. Run the tests:
+
+```bash
+./gradlew test
+```
+
+3. Initially, the test will fail. Fix the TODO in `src/main/java/com/example/Calculator.java` so that `Calculator.add` correctly adds two numbers.
+4. Re-run the tests. When the test passes, a Discord invitation link will be printed to the console.
+
+## Discord Link
+The link printed upon success is:
+
+```
+https://discord.example.com
+```
+
+Feel free to update this link to your actual community invite.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'JavaTest'

--- a/src/main/java/com/example/Calculator.java
+++ b/src/main/java/com/example/Calculator.java
@@ -1,0 +1,11 @@
+package com.example;
+
+public class Calculator {
+    /**
+     * Adds two integers. This method contains a bug that candidates need to fix.
+     */
+    public static int add(int a, int b) {
+        // TODO: Fix the bug to correctly add two numbers
+        return a - b; // intentionally incorrect
+    }
+}

--- a/src/test/java/com/example/CalculatorTest.java
+++ b/src/test/java/com/example/CalculatorTest.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CalculatorTest {
+    @Test
+    public void testAdd() {
+        assertEquals(2, Calculator.add(1, 1));
+        System.out.println("Congratulations! Join our Discord: https://discord.example.com");
+    }
+}


### PR DESCRIPTION
## Summary
- set up Gradle project with JUnit 5
- add simple `Calculator` class with a bug
- add failing unit test that prints Discord link on success
- document how to run the challenge in `README`
- extend `.gitignore`

## Testing
- `gradle test --no-daemon` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_e_68419c4302508332afd4d65026f4f994