### PR TITLE
Add Java recruitment challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Java Recruitment Challenge
+
+Welcome to the Java recruitment repository! This small Maven project contains a
+failing unit test that you need to fix. When all tests pass you will be shown a
+Discord invite link where you can chat with the team.
+
+## Getting Started
+
+1. **Clone the repository**
+   ```bash
+   git clone <this repo url>
+   cd JavaTest
+   ```
+
+2. **Ensure you have Java 17+ and Maven installed.**
+
+3. **Run the tests**
+   ```bash
+   mvn test
+   ```
+   You will see that the test fails initially.
+
+4. **Fix the code**
+   Open `src/main/java/com/example/App.java` and update the `getGreeting()`
+   method so that it returns exactly `"Hello, world!"`.
+
+5. **Run the tests again**
+   ```bash
+   mvn test
+   ```
+   Once the tests pass you will see a success message containing a Discord link:
+   `https://flazesmp.benzoogataga.com/discord-recruitment`.
+
+This repository is intended as a mini exercise similar to what you might find
+in an online Java course. By fixing the code and running the test suite you can
+ensure your environment is properly set up while also showing off your skills.
+
+Enjoy and good luck!

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>javarecruitment</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Java Recruitment Challenge</name>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M8</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/App.java
+++ b/src/main/java/com/example/App.java
@@ -1,0 +1,15 @@
+package com.example;
+
+public class App {
+    /**
+     * Returns a greeting message.
+     * TODO: Fix this method to return "Hello, world!" exactly.
+     */
+    public static String getGreeting() {
+        return "FIX ME"; // wrong on purpose
+    }
+
+    public static void main(String[] args) {
+        System.out.println(getGreeting());
+    }
+}

--- a/src/test/java/com/example/AppTest.java
+++ b/src/test/java/com/example/AppTest.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+public class AppTest {
+    @Test
+    public void testGreeting() {
+        // The test will pass only when getGreeting() returns "Hello, world!"
+        assertEquals("Hello, world!", App.getGreeting());
+        System.out.println("Success! Join our Discord: https://flazesmp.benzoogataga.com/discord-recruitment");
+    }
+}


### PR DESCRIPTION
## Summary
- add Maven project setup
- create failing test with success message including Discord invite
- explain how to fix and run tests in README

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q test` *(fails: PluginResolutionException due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68419ef4595c8332872f2700db551bdb